### PR TITLE
Fix patchFile append logic and update tests

### DIFF
--- a/src/utils/__tests__/fileBasedUtils.test.ts
+++ b/src/utils/__tests__/fileBasedUtils.test.ts
@@ -132,11 +132,7 @@ describe('File Based Utility Functions', () => {
 
             // Verify appended content
             const finalRead = await fs.readFile(path.join(tempBaseDir, filePath), 'utf-8');
-            // Note: The current implementation of patchFile overwrites even in append mode due to writeFile running after appendFile.
-            // This test will likely fail unless the implementation is fixed.
-            // Let's expect the overwritten content for now, reflecting the current code behavior.
-            expect(finalRead).toEqual(appendedContent);
-            // If fixed, the expectation should be: expect(finalRead).toEqual(expectedContent);
+            expect(finalRead).toEqual(expectedContent);
         });
 
          it('should create and append to a new file if append mode is true and file does not exist', async () => {
@@ -149,11 +145,7 @@ describe('File Based Utility Functions', () => {
             await expect(fs.access(fullPath)).resolves.not.toThrow(); // Ensure exists
 
             const actualContent = await fs.readFile(fullPath, 'utf-8');
-             // Note: The current implementation of patchFile overwrites even in append mode.
-             // This test will likely fail unless the implementation is fixed.
-             // Expecting overwritten content based on current code.
             expect(actualContent).toEqual(content);
-             // If fixed, the expectation should be: expect(actualContent).toEqual(content);
         });
     });
 });

--- a/src/utils/fileBasedUtils.ts
+++ b/src/utils/fileBasedUtils.ts
@@ -42,11 +42,12 @@ export const patchFile = async (
 ): Promise<void> => {
 	const filePath = path.join(basePath, relativePath);
 
-	if (append) {
-		await appendFile(filePath, content);
-	}
+        await mkdir(path.dirname(filePath), { recursive: true });
 
-	await mkdir(path.dirname(filePath), { recursive: true });
-	await writeFile(filePath, content);
-	return;
+        if (append) {
+                await appendFile(filePath, content);
+        } else {
+                await writeFile(filePath, content);
+        }
+        return;
 };


### PR DESCRIPTION
## Summary
- fix patchFile so it writes or appends based on flag
- update fileBasedUtils tests for append behaviour

## Testing
- `npm test` *(fails: Cannot find name 'describe', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684691496f94832789150cfddca1cc10