### PR TITLE
Ensure CPI_BASE_URL presence

### DIFF
--- a/src/api/__tests__/sendMessageToCPI.test.ts
+++ b/src/api/__tests__/sendMessageToCPI.test.ts
@@ -69,6 +69,17 @@ describe("Send Message to CPI API", () => {
         }
     });
 
+    it('should throw an error if CPI_BASE_URL is not defined', async () => {
+        const currentBaseUrl = process.env.CPI_BASE_URL;
+        delete process.env.CPI_BASE_URL;
+
+        await expect(sendRequestToCPI('/http/test', 'GET', 'application/json')).rejects.toThrow(
+            'CPI_BASE_URL environment variable is not defined'
+        );
+
+        process.env.CPI_BASE_URL = currentBaseUrl;
+    });
+
     // Add a test that tries to hit a potentially real endpoint (if if_echo_mapping was deployed)
     // This is less reliable as it depends on previous test suites' success
     // Skipping due to flakiness
@@ -125,3 +136,4 @@ describe("Send Message to CPI API", () => {
     });
 
 });
+

--- a/src/api/messages/sendMessageToCPI.ts
+++ b/src/api/messages/sendMessageToCPI.ts
@@ -14,6 +14,10 @@ export const sendRequestToCPI = async (
     logInfo(body);
     logInfo(headers);
 
+    if (!process.env["CPI_BASE_URL"]) {
+        throw new Error("CPI_BASE_URL environment variable is not defined");
+    }
+
     const authHeader = (await getOAuthTokenCPI()).http_header;
 
     const reqHeaders = {

--- a/src/utils/__tests__/getEndpointUrl.test.ts
+++ b/src/utils/__tests__/getEndpointUrl.test.ts
@@ -74,16 +74,16 @@ describe('getEndpointUrl Utility Function', () => {
         expect(getEndpointUrl(mockEndpoint)).toEqual('');
     });
 
-     it('should return an empty string if CPI_BASE_URL is not set', () => {
+    it('should return an empty string if CPI_BASE_URL is not set', () => {
         const currentBaseUrl = process.env['CPI_BASE_URL'];
-        delete process.env['CPI_BASE_URL']; // Temporarily remove env var
+        delete process.env['CPI_BASE_URL'];
 
         const endpointId = 'myRestEndpoint';
         const mockEndpoint = createMockEndpoint(endpointId, 'REST');
-        // The function currently returns 'undefined/http/myRestEndpoint' if base URL is missing.
-        // Let's test for that specific behavior, although returning '' might be better.
-        expect(getEndpointUrl(mockEndpoint)).toEqual(`undefined/http/${endpointId}`);
 
-        process.env['CPI_BASE_URL'] = currentBaseUrl; // Restore env var
+        expect(getEndpointUrl(mockEndpoint)).toEqual('');
+
+        process.env['CPI_BASE_URL'] = currentBaseUrl;
     });
 });
+

--- a/src/utils/getEndpointUrl.ts
+++ b/src/utils/getEndpointUrl.ts
@@ -42,6 +42,10 @@ export const getEndpointUrl = (endpoint: ServiceEndpoints): string => {
         return '';
     }
 
-    // for now only supports https:// 
+    // for now only supports https://
+    if (!process.env['CPI_BASE_URL']) {
+        return '';
+    }
     return `${process.env['CPI_BASE_URL']}${protocolObj.URIProtocol}${endpointIdentifier}`;
 }
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
         "strict": true,                                      /* Enable all strict type-checking options. */
         "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
         "sourceMap": true,
-        "types": ["node"]
+        "types": ["node", "jest"]
         },
     "include": ["src/**/*"],
     "exclude": ["**/*.test.ts", "node_modules"]


### PR DESCRIPTION
## Summary
- throw error in `sendMessageToCPI` when `CPI_BASE_URL` is missing
- return empty string from `getEndpointUrl` when `CPI_BASE_URL` is undefined
- update related unit tests
- include Jest typings for TypeScript

## Testing
- `npm test` *(fails: Cannot find module '../../generated/IntegrationContent')*

------
https://chatgpt.com/codex/tasks/task_e_684692e051f88327992749ba8e4b7af7