### PR TITLE
Fix trailingProtocol map

### DIFF
--- a/src/utils/getEndpointUrl.ts
+++ b/src/utils/getEndpointUrl.ts
@@ -4,20 +4,16 @@ import { ServiceEndpoints } from "../generated/IntegrationContent";
 /**
  * Translate internal CPI Protocol names
  */
-const cpiProtocolMap: { [protocol: string]: { trailingProtocol: string, URIProtocol: string } } = {
+const cpiProtocolMap: { [protocol: string]: { URIProtocol: string } } = {
     "REST": {
-        trailingProtocol: 'https',
         URIProtocol: '/http/',
     },
     "AS2": {
-        trailingProtocol: 'https',
         URIProtocol: '/as2/as2/'
     },
     "SOAP": {
-        trailingProtocol: 'https',
         URIProtocol: '/cfx/soapapi/'
     }
-
 };
 
 /**


### PR DESCRIPTION
## Summary
- clean up unused `trailingProtocol` field from `cpiProtocolMap`

## Testing
- `npm test` *(fails: Cannot find generated packages)*

------
https://chatgpt.com/codex/tasks/task_e_684695b1279083278f768fa6118f7d62