### PR TITLE
Fix typo in API destination helper

### DIFF
--- a/src/api/__tests__/api_destination.test.ts
+++ b/src/api/__tests__/api_destination.test.ts
@@ -1,5 +1,5 @@
 import { config } from "dotenv";
-import { getOAuthToken, getCurrentDestionation } from "../api_destination";
+import { getOAuthToken, getCurrentDestination } from "../api_destination";
 import path from "path";
 import { projPath } from "../..";
 
@@ -45,7 +45,7 @@ describe("API Destination Handling", () => {
             }
         });
 
-        it("should throw an error if OAuth env vars are missing and it's called directly (though getCurrentDestionation handles this)", async () => {
+        it("should throw an error if OAuth env vars are missing and it's called directly (though getCurrentDestination handles this)", async () => {
             // Only run this if OAuth vars are NOT set but Basic Auth vars MIGHT be set (or neither)
             if (process.env.API_OAUTH_CLIENT_ID || process.env.API_OAUTH_CLIENT_SECRET || process.env.API_OAUTH_TOKEN_URL) {
                 console.warn("Skipping direct getOAuthToken error test: OAuth variables seem to be present.");
@@ -57,13 +57,13 @@ describe("API Destination Handling", () => {
         });
     });
 
-    // --- Tests for getCurrentDestionation ---
-    describe("getCurrentDestionation", () => {
+    // --- Tests for getCurrentDestination ---
+    describe("getCurrentDestination", () => {
         it("should throw an error if API_BASE_URL is missing", async () => {
             const originalBaseUrl = process.env.API_BASE_URL;
             delete process.env.API_BASE_URL; // Temporarily remove the variable
 
-            await expect(getCurrentDestionation()).rejects.toThrow("No API Url provided in project .env file");
+            await expect(getCurrentDestination()).rejects.toThrow("No API Url provided in project .env file");
 
             process.env.API_BASE_URL = originalBaseUrl; // Restore the variable
         });
@@ -83,7 +83,7 @@ describe("API Destination Handling", () => {
             delete process.env.API_USER;
             delete process.env.API_PASS;
 
-            await expect(getCurrentDestionation()).rejects.toThrow("No Authentication method provided in project .env file");
+            await expect(getCurrentDestination()).rejects.toThrow("No Authentication method provided in project .env file");
 
             // Restore variables
             config({ path: path.join(projPath, '.env') });
@@ -94,12 +94,12 @@ describe("API Destination Handling", () => {
         it("should return OAuth destination if OAuth env vars are set", async () => {
             // Add specific check for API_OAUTH_TOKEN_URL as well, as getOAuthToken now requires it
             if (!process.env.API_BASE_URL || !process.env.API_OAUTH_CLIENT_ID || !process.env.API_OAUTH_CLIENT_SECRET || !process.env.API_OAUTH_TOKEN_URL) {
-                console.warn("Skipping getCurrentDestionation (OAuth) test: Required environment variables (API_BASE_URL, API_OAUTH_CLIENT_ID, API_OAUTH_CLIENT_SECRET, API_OAUTH_TOKEN_URL) are not set.");
+                console.warn("Skipping getCurrentDestination (OAuth) test: Required environment variables (API_BASE_URL, API_OAUTH_CLIENT_ID, API_OAUTH_CLIENT_SECRET, API_OAUTH_TOKEN_URL) are not set.");
                 return;
             }
 
             try {
-                const destination = await getCurrentDestionation();
+                const destination = await getCurrentDestination();
                 expect(destination).toBeDefined();
                 // Use string literal for AuthenticationType comparison
                 expect(destination.authentication).toEqual("OAuth2ClientCredentials");
@@ -114,7 +114,7 @@ describe("API Destination Handling", () => {
                 expect(destination.authTokens![0].expiresIn).toBeDefined();
                 expect(destination.authTokens![0].http_header).toBeDefined();
             } catch (error) {
-                console.error("Error during getCurrentDestionation (OAuth) test:", error);
+                console.error("Error during getCurrentDestination (OAuth) test:", error);
                 throw error;
             }
         });
@@ -122,12 +122,12 @@ describe("API Destination Handling", () => {
         it("should return Basic Auth destination if Basic Auth env vars are set (and OAuth is not)", async () => {
 
             if (!process.env.API_BASE_URL || !process.env.API_USER || !process.env.API_PASS) {
-                console.warn("Skipping getCurrentDestionation (Basic) test: Required environment variables (API_BASE_URL, API_USER, API_PASS) are not set.");
+                console.warn("Skipping getCurrentDestination (Basic) test: Required environment variables (API_BASE_URL, API_USER, API_PASS) are not set.");
                 return;
             }
 
             try {
-                const destination = await getCurrentDestionation();
+                const destination = await getCurrentDestination();
                 expect(destination).toBeDefined();
                 // Use string literal for AuthenticationType comparison
                 expect(destination.authentication).toEqual("BasicAuthentication");
@@ -135,7 +135,7 @@ describe("API Destination Handling", () => {
                 expect(destination.username).toEqual(process.env.API_USER);
                 expect(destination.password).toEqual(process.env.API_PASS);
             } catch (error) {
-                console.error("Error during getCurrentDestionation (Basic) test:", error);
+                console.error("Error during getCurrentDestination (Basic) test:", error);
                 throw error;
             }
         });

--- a/src/api/__tests__/helpers.ts
+++ b/src/api/__tests__/helpers.ts
@@ -1,7 +1,7 @@
 import { integrationContent } from "../../generated/IntegrationContent";
-import { getCurrentDestionation } from "../api_destination";
+import { getCurrentDestination } from "../api_destination";
 
 export const deletePackage = async(pkgId: string) => {
     const { integrationPackagesApi } = integrationContent();
-            await integrationPackagesApi.requestBuilder().delete(pkgId).execute(await getCurrentDestionation());
+            await integrationPackagesApi.requestBuilder().delete(pkgId).execute(await getCurrentDestination());
 }

--- a/src/api/__tests__/packages.test.ts
+++ b/src/api/__tests__/packages.test.ts
@@ -3,7 +3,7 @@ import { createPackage, getPackage, getPackages } from "../packages/index";
 // Correct the relative path from src/api/__tests__/ to src/generated/
 import { integrationContent, IntegrationPackages } from "../../generated/IntegrationContent/index";
 import dotenv from 'dotenv';
-import { getCurrentDestionation } from "../api_destination";
+import { getCurrentDestination } from "../api_destination";
 import { deletePackage } from "./helpers";
 
 // Load environment variables from .env file

--- a/src/api/api_destination.ts
+++ b/src/api/api_destination.ts
@@ -87,8 +87,8 @@ const isBasicCredPresent = () => process.env.API_USER && process.env.API_PASS ? 
  * Get the API Destination based on .env file
  * @returns
  */
-export const getCurrentDestionation =
-	async (): Promise<HttpDestinationOrFetchOptions> => {
+export const getCurrentDestination =
+        async (): Promise<HttpDestinationOrFetchOptions> => {
 		if (!process.env.API_BASE_URL) {
 			throw new Error("No API Url provided in project .env file");
 		}

--- a/src/api/deployment.ts
+++ b/src/api/deployment.ts
@@ -2,7 +2,7 @@ import {
 	deployIntegrationDesigntimeArtifact,
 	integrationContent,
 } from "../generated/IntegrationContent";
-import { getCurrentDestionation } from "./api_destination";
+import { getCurrentDestination } from "./api_destination";
 
 const { buildAndDeployStatusApi, integrationRuntimeArtifactsApi } =
 	integrationContent();
@@ -22,13 +22,13 @@ export const waitAndGetDeployStatus = async (
 	let statusObj = await buildAndDeployStatusApi
 		.requestBuilder()
 		.getByKey(taskId)
-		.execute(await getCurrentDestionation());
+                .execute(await getCurrentDestination());
 
 	while (statusObj.status === "DEPLOYING") {
 		statusObj = await buildAndDeployStatusApi
 			.requestBuilder()
 			.getByKey(taskId)
-			.execute(await getCurrentDestionation());
+                        .execute(await getCurrentDestination());
 		await sleep(1000);
 	}
 
@@ -51,5 +51,5 @@ export const getDeploymentErrorReason = async (
 		.requestBuilder()
 		.getByKey(id)
 		.appendPath("/ErrorInformation/$value")
-		.executeRaw(await getCurrentDestionation())).data;
+                .executeRaw(await getCurrentDestination())).data;
 };

--- a/src/api/iflow/index.ts
+++ b/src/api/iflow/index.ts
@@ -1,6 +1,6 @@
 
 import { extractToFolder, folderToZipBuffer } from "../../utils/zip";
-import { getCurrentDestionation, getOAuthToken } from "../api_destination";
+import { getCurrentDestination, getOAuthToken } from "../api_destination";
 import { updateFiles } from "../../handlers/iflow/tools";
 
 import { z } from "zod";
@@ -34,7 +34,7 @@ export const getIflowFolder = async (id: string): Promise<string> => {
 		.getByKey(id, "active")
 		.appendPath("/$value")
 		.addCustomRequestConfiguration({ responseType: "arraybuffer" })
-		.executeRaw(await getCurrentDestionation());
+		.executeRaw(await getCurrentDestination());
 
 	const arrBuffer = await iflowBuffer.data;
 
@@ -62,7 +62,7 @@ export const createIflow = async (
 	await integrationDesigntimeArtifactsApi
 		.requestBuilder()
 		.create(newIflow)
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };
 
 /**
@@ -103,7 +103,7 @@ export const updateIflow = async (
 		.requestBuilder()
 		.update(newIflowEntity)
 		.replaceWholeEntityWithPut()
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 
 	return {
 		iflowUpdate: {
@@ -121,7 +121,7 @@ export const saveAsNewVersion = async (id: string) => {
 	const currentIflow = await integrationDesigntimeArtifactsApi
 		.requestBuilder()
 		.getByKey(id, "active")
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 
 	const newVersion = semver.inc(currentIflow.version, "patch");
 
@@ -136,7 +136,7 @@ export const saveAsNewVersion = async (id: string) => {
 	await integrationDesigntimeArtifactSaveAsVersion({
 		id,
 		saveAsVersion: newVersion,
-	}).execute(await getCurrentDestionation());
+	}).execute(await getCurrentDestination());
 };
 
 /**
@@ -164,10 +164,10 @@ export const getEndpoints = async (id?: string) => {
 	}
 
 	logInfo(
-		`Requesting Endpoints on ${await endpointRequest.url(await getCurrentDestionation())}`
+		`Requesting Endpoints on ${await endpointRequest.url(await getCurrentDestination())}`
 	);
 	const endpoints = await endpointRequest.execute(
-		await getCurrentDestionation()
+		await getCurrentDestination()
 	);
 	const endpointsWithUrl: (ServiceEndpoints & { URL?: string })[] = endpoints;
 
@@ -188,7 +188,7 @@ export const deployIflow = async (id: string): Promise<string> => {
 	const deployRes = await deployIntegrationDesigntimeArtifact({
 		id,
 		version: "active",
-	}).executeRaw(await getCurrentDestionation());
+	}).executeRaw(await getCurrentDestination());
 
 	if (deployRes.status !== 202) {
 		throw new Error("Error starting deployment of " + id);
@@ -206,7 +206,7 @@ export const getIflowConfiguration = async (
 		.requestBuilder()
 		.getByKey(iflowId, "active")
 		.appendPath("/Configurations")
-		.executeRaw(await getCurrentDestionation());
+		.executeRaw(await getCurrentDestination());
 
 	if (configurationRes.status !== 200 || !configurationRes.data.d.results) {
 		throw new Error(
@@ -230,7 +230,7 @@ export const getAllIflowsByPackage = async (
 		.requestBuilder()
 		.getByKey(pkgId)
 		.appendPath("/IntegrationDesigntimeArtifacts")
-		.executeRaw(await getCurrentDestionation());
+		.executeRaw(await getCurrentDestination());
 	integrationDesigntimeArtifactsApi.schema;
 	if (allIflowsRes.status !== 200 || !allIflowsRes?.data?.d?.results) {
 		throw new Error(

--- a/src/api/mappings/index.ts
+++ b/src/api/mappings/index.ts
@@ -7,7 +7,7 @@ import {
 import { updateFiles } from "../../handlers/iflow/tools";
 import { parseFolder, patchFile } from "../../utils/fileBasedUtils";
 import { extractToFolder, folderToZipBuffer } from "../../utils/zip";
-import { getCurrentDestionation, getOAuthToken } from "../api_destination";
+import { getCurrentDestination, getOAuthToken } from "../api_destination";
 import { z } from "zod";
 import semver from "semver";
 import { executeHttpRequest } from "@sap-cloud-sdk/http-client";
@@ -27,7 +27,7 @@ export const getMessageMappingFolder = async (id: string): Promise<string> => {
 		.getByKey(id, "active")
 		.appendPath("/$value")
 		.addCustomRequestConfiguration({ responseType: "arraybuffer" })
-		.executeRaw(await getCurrentDestionation());
+		.executeRaw(await getCurrentDestination());
 
 	const buf = Buffer.from(arrBuffer.data);
 	return extractToFolder(buf, id);
@@ -56,9 +56,9 @@ export const updateMessageMapping = async (
 	const url = await messageMappingDesigntimeArtifactsApi
 		.requestBuilder()
 		.getByKey(id, "active")
-		.url(await getCurrentDestionation());
+		.url(await getCurrentDestination());
 
-	const res = await executeHttpRequest(await getCurrentDestionation(), {
+	const res = await executeHttpRequest(await getCurrentDestination(), {
 		url,
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },
@@ -84,7 +84,7 @@ export const saveAsNewVersion = async (id: string) => {
 	const currentMessageMapping = await messageMappingDesigntimeArtifactsApi
 		.requestBuilder()
 		.getByKey(id, "active")
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 
 	const newVersion = semver.inc(currentMessageMapping.version, "patch");
 
@@ -99,7 +99,7 @@ export const saveAsNewVersion = async (id: string) => {
 	await messageMappingDesigntimeArtifactSaveAsVersion({
 		id,
 		saveAsVersion: newVersion,
-	}).execute(await getCurrentDestionation());
+	}).execute(await getCurrentDestination());
 };
 
 /**
@@ -111,7 +111,7 @@ export const deployMapping = async (id: string): Promise<string> => {
 	const deployRes = await deployMessageMappingDesigntimeArtifact({
 		id,
 		version: "active",
-	}).executeRaw(await getCurrentDestionation());
+	}).executeRaw(await getCurrentDestination());
 
 	if (deployRes.status !== 202) {
 		throw new Error("Error starting deployment of " + id);
@@ -141,11 +141,11 @@ export const createMessageMapping = async (
 	await messageMappingDesigntimeArtifactsApi
 		.requestBuilder()
 		.create(newMessageMapping)
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };
 
 export const getAllMessageMappings = async () =>
 	messageMappingDesigntimeArtifactsApi
 		.requestBuilder()
 		.getAll()
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());

--- a/src/api/messages/messageLogs.ts
+++ b/src/api/messages/messageLogs.ts
@@ -12,7 +12,7 @@ import {
 import { DeSerializers, or } from "@sap-cloud-sdk/odata-v2";
 import { and, Filter, FilterList } from "@sap-cloud-sdk/odata-common";
 import moment, { Moment } from "moment";
-import { getCurrentDestionation } from "../api_destination";
+import { getCurrentDestination } from "../api_destination";
 import { createIflow } from "../iflow";
 import { integrationContent } from "../../generated/IntegrationContent";
 import { folderToZipBuffer } from "../../utils/zip";
@@ -102,12 +102,12 @@ export const getMessages = async (
 		.top(50)
 		.filter(getFilters(filterProps));
 
-	logInfo(await messageBaseReq.url(await getCurrentDestionation()));
+	logInfo(await messageBaseReq.url(await getCurrentDestination()));
 
 	const messageWithErrVal: (MessageProcessingLogs & {
 		ErrorInformationValue?: string;
 		messageAttachementFiles?: { description?: string; data: string }[];
-	})[] = await messageBaseReq.execute(await getCurrentDestionation());
+	})[] = await messageBaseReq.execute(await getCurrentDestination());
 
 	logInfo(`Found ${messageWithErrVal.length} messages`);
 
@@ -120,7 +120,7 @@ export const getMessages = async (
 						.requestBuilder()
 						.getByKey(message.messageGuid)
 						.appendPath("/AdapterAttributes")
-						.executeRaw(await getCurrentDestionation())
+						.executeRaw(await getCurrentDestination())
 				).data;
 			} catch (error) {
 				logInfo(
@@ -134,7 +134,7 @@ export const getMessages = async (
 						.requestBuilder()
 						.getByKey(message.messageGuid)
 						.appendPath("/CustomHeaderProperties")
-						.executeRaw(await getCurrentDestionation())
+						.executeRaw(await getCurrentDestination())
 				).data.d.results;
 			} catch (error) {
 				logInfo(
@@ -149,7 +149,7 @@ export const getMessages = async (
 						.requestBuilder()
 						.getByKey(message.messageGuid)
 						.appendPath("/Attachments")
-						.executeRaw(await getCurrentDestionation())
+						.executeRaw(await getCurrentDestination())
 				).data.d.results;
 
 				logInfo(
@@ -176,7 +176,7 @@ export const getMessages = async (
 						.requestBuilder()
 						.getByKey(message.messageGuid)
 						.appendPath("/Attachments")
-						.url(await getCurrentDestionation())
+						.url(await getCurrentDestination())
 				);
 				logInfo(error);
 			}
@@ -191,14 +191,14 @@ export const getMessages = async (
 							.requestBuilder()
 							.getByKey(message.messageGuid)
 							.appendPath("/ErrorInformation")
-							.executeRaw(await getCurrentDestionation())
+							.executeRaw(await getCurrentDestination())
 					).data.d.results;
 					message.ErrorInformationValue = (
 						await messageProcessingLogsApi
 							.requestBuilder()
 							.getByKey(message.messageGuid)
 							.appendPath("/ErrorInformation/$value")
-							.executeRaw(await getCurrentDestionation())
+							.executeRaw(await getCurrentDestination())
 					).data;
 				} catch (error) {
 					logInfo(
@@ -224,7 +224,7 @@ export const getMessagesCount = async (
 		.getAll()
 		.filter(getFilters(filterProps))
 		.count()
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };
 
 /**
@@ -240,7 +240,7 @@ export const getMessageMedia = async (mediaId: string): Promise<string> => {
 			.requestBuilder()
 			.getByKey(mediaId)
 			.appendPath("/$value")
-			.executeRaw(await getCurrentDestionation())
+			.executeRaw(await getCurrentDestination())
 	).data;
 };
 
@@ -249,7 +249,7 @@ export const createMappingTestIflow = async (pkgId: string) => {
 		await integrationDesigntimeArtifactsApi
 			.requestBuilder()
 			.delete("if_echo_mapping", "active")
-			.execute(await getCurrentDestionation());
+			.execute(await getCurrentDestination());
 	} catch (error) {}
 
 	const iflowBuffer = await folderToZipBuffer(
@@ -268,5 +268,5 @@ export const createMappingTestIflow = async (pkgId: string) => {
 	await integrationDesigntimeArtifactsApi
 		.requestBuilder()
 		.create(newIflow)
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };

--- a/src/api/packages/index.ts
+++ b/src/api/packages/index.ts
@@ -1,6 +1,6 @@
 
 import { integrationContent } from "../../generated/IntegrationContent";
-import { getCurrentDestionation } from "../api_destination"; // Removed .js again
+import { getCurrentDestination } from "../api_destination"; // Removed .js again
 
 const { integrationPackagesApi } = integrationContent();
 
@@ -8,14 +8,14 @@ export const getPackages = async () => {
 	return integrationPackagesApi
 		.requestBuilder()
 		.getAll()
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };
 
 export const getPackage = async (id: string) => {
 	return integrationPackagesApi
 		.requestBuilder()
 		.getByKey(id)
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };
 
 export const createPackage = async (
@@ -32,5 +32,5 @@ export const createPackage = async (
 	return integrationPackagesApi
 		.requestBuilder()
 		.create(newPackage)
-		.execute(await getCurrentDestionation());
+		.execute(await getCurrentDestination());
 };


### PR DESCRIPTION
## Summary
- rename `getCurrentDestionation` to `getCurrentDestination`
- update all references across API utilities and tests

## Testing
- `npm run build:tsc` *(fails: Cannot find module '../../generated/...')*
- `npm test` *(fails: Cannot find module '../../generated/...')*

------
https://chatgpt.com/codex/tasks/task_e_6846a38ded1883278fd5d1bcbcca00fc