### PR TITLE
Fix env check logic in sendMessageToCPI tests

### DIFF
--- a/src/api/__tests__/sendMessageToCPI.test.ts
+++ b/src/api/__tests__/sendMessageToCPI.test.ts
@@ -9,15 +9,31 @@ describe("Send Message to CPI API", () => {
     // Increase timeout for network requests
     jest.setTimeout(30000); // 30 seconds
 
+    let cpiEnvAvailable = true;
+
     // Check prerequisites before running tests
     beforeAll(() => {
-        if (!process.env.CPI_BASE_URL || !process.env.CPI_OAUTH_CLIENT_ID || !process.env.CPI_OAUTH_CLIENT_SECRET || !process.env.CPI_OAUTH_TOKEN_URL) {
-            // Skip all tests in this suite if CPI runtime env vars are missing
-            throw new Error("Missing required environment variables for CPI connection (CPI_BASE_URL, CPI_OAUTH...). Skipping Send Message tests.");
+        cpiEnvAvailable = Boolean(
+            process.env.CPI_BASE_URL &&
+            process.env.CPI_OAUTH_CLIENT_ID &&
+            process.env.CPI_OAUTH_CLIENT_SECRET &&
+            process.env.CPI_OAUTH_TOKEN_URL
+        );
+
+        if (!cpiEnvAvailable) {
+            console.warn(
+                "Skipping Send Message tests: Required environment variables (CPI_BASE_URL, CPI_OAUTH_CLIENT_ID, CPI_OAUTH_CLIENT_SECRET, CPI_OAUTH_TOKEN_URL) are not set."
+            );
+            return;
         }
     });
 
     it("should attempt to send a GET request and handle the response status", async () => {
+        if (!cpiEnvAvailable) {
+            console.warn("Skipping GET request test: CPI environment variables are not set.");
+            return;
+        }
+
         const testPath = `/http/jest_test_nonexistent_endpoint_${Date.now()}`; // Use a likely non-existent path
         const method = "GET";
         const contentType = "application/json"; // Not relevant for GET body, but required by function
@@ -44,6 +60,11 @@ describe("Send Message to CPI API", () => {
     });
 
     it("should attempt to send a POST request and handle the response status", async () => {
+        if (!cpiEnvAvailable) {
+            console.warn("Skipping POST request test: CPI environment variables are not set.");
+            return;
+        }
+
         // Sending to the same non-existent path, expecting 404
         const testPath = `/http/jest_test_nonexistent_endpoint_post_${Date.now()}`;
         const method = "POST";


### PR DESCRIPTION
## Summary
- skip sendMessageToCPI tests when CPI env vars are missing
- check env vars before running each sendMessageToCPI test

## Testing
- `npm install` *(fails: puppeteer chrome download 403)*
- `npm test` *(command not found because install failed)*

------
https://chatgpt.com/codex/tasks/task_e_6846aad756ec83278952f55668b59ce4