### PR TITLE
Fix test error handling

### DIFF
--- a/src/api/__tests__/api_destination.test.ts
+++ b/src/api/__tests__/api_destination.test.ts
@@ -1,5 +1,6 @@
 import { config } from "dotenv";
 import { getOAuthToken, getCurrentDestination } from "../api_destination";
+import { safeStringify } from "./helpers";
 import path from "path";
 import { projPath } from "../..";
 
@@ -40,8 +41,11 @@ describe("API Destination Handling", () => {
                 expect(cachedToken.value).toEqual(token.value);
 
             } catch (error) {
-                console.error("Error during getOAuthToken (Management API) test:", error);
-                throw error;
+                console.error(
+                    "Error during getOAuthToken (Management API) test:",
+                    safeStringify(error)
+                );
+                throw new Error((error as Error).message);
             }
         });
 
@@ -114,8 +118,11 @@ describe("API Destination Handling", () => {
                 expect(destination.authTokens![0].expiresIn).toBeDefined();
                 expect(destination.authTokens![0].http_header).toBeDefined();
             } catch (error) {
-                console.error("Error during getCurrentDestination (OAuth) test:", error);
-                throw error;
+                console.error(
+                    "Error during getCurrentDestination (OAuth) test:",
+                    safeStringify(error)
+                );
+                throw new Error((error as Error).message);
             }
         });
 
@@ -135,8 +142,11 @@ describe("API Destination Handling", () => {
                 expect(destination.username).toEqual(process.env.API_USER);
                 expect(destination.password).toEqual(process.env.API_PASS);
             } catch (error) {
-                console.error("Error during getCurrentDestination (Basic) test:", error);
-                throw error;
+                console.error(
+                    "Error during getCurrentDestination (Basic) test:",
+                    safeStringify(error)
+                );
+                throw new Error((error as Error).message);
             }
         });
     });

--- a/src/api/__tests__/cpi_auth.test.ts
+++ b/src/api/__tests__/cpi_auth.test.ts
@@ -1,5 +1,6 @@
 import { getOAuthTokenCPI } from "../cpi_auth";
 import dotenv from 'dotenv';
+import { safeStringify } from "./helpers";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -40,8 +41,11 @@ describe("CPI Authentication API", () => {
 
         } catch (error) {
             // Log the error for debugging but fail the test
-            console.error("Error during getOAuthTokenCPI test:", error);
-            throw error; // Re-throw to fail the test
+            console.error(
+                "Error during getOAuthTokenCPI test:",
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message); // Re-throw to fail the test
         }
     });
 });

--- a/src/api/__tests__/helpers.ts
+++ b/src/api/__tests__/helpers.ts
@@ -1,7 +1,30 @@
 import { integrationContent } from "../../generated/IntegrationContent";
 import { getCurrentDestination } from "../api_destination";
 
-export const deletePackage = async(pkgId: string) => {
+export const deletePackage = async (pkgId: string) => {
     const { integrationPackagesApi } = integrationContent();
-            await integrationPackagesApi.requestBuilder().delete(pkgId).execute(await getCurrentDestination());
-}
+    await integrationPackagesApi
+        .requestBuilder()
+        .delete(pkgId)
+        .execute(await getCurrentDestination());
+};
+
+export const safeStringify = (obj: unknown): string => {
+    const seen = new WeakSet();
+    return JSON.stringify(
+        obj,
+        (key, value) => {
+            if (typeof value === "object" && value !== null) {
+                if (seen.has(value)) {
+                    return "[Circular]";
+                }
+                seen.add(value);
+            }
+            if (typeof value === "function") {
+                return value.toString();
+            }
+            return value;
+        },
+        2
+    );
+};

--- a/src/api/__tests__/iflow.test.ts
+++ b/src/api/__tests__/iflow.test.ts
@@ -15,7 +15,7 @@ import { getiFlowToImage } from '../iflow/diagram'; // Import the diagram functi
 import dotenv from 'dotenv';
 import path from 'path';
 import fs from 'fs/promises';
-import { deletePackage } from "./helpers";
+import { deletePackage, safeStringify } from "./helpers";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -44,7 +44,10 @@ describe("IFlow Management API", () => {
             packageCreated = true;
             console.log(`Test package ${testPackageId} created successfully.`);
         } catch (error) {
-            console.error(`Failed to create test package ${testPackageId}. IFlow tests will likely fail. Error:`, error);
+            console.error(
+                `Failed to create test package ${testPackageId}. IFlow tests will likely fail. Error:`,
+                safeStringify(error)
+            );
             // Throwing error here as subsequent tests depend heavily on the package
             throw new Error(`Failed to create prerequisite package ${testPackageId}`);
         }
@@ -62,8 +65,11 @@ describe("IFlow Management API", () => {
             const found = iflows.some((iflow: any) => iflow.Id === testIflowId);
             expect(found).toBe(true);
         } catch (error) {
-            console.error(`Error during createIflow test for ${testIflowId} in package ${testPackageId}:`, error);
-            throw error;
+            console.error(
+                `Error during createIflow test for ${testIflowId} in package ${testPackageId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -78,8 +84,11 @@ describe("IFlow Management API", () => {
             const found = iflows.some((iflow: any) => iflow.Id === testIflowId);
             expect(found).toBe(true);
         } catch (error) {
-            console.error(`Error during getAllIflowsByPackage test for package ${testPackageId}:`, error);
-            throw error;
+            console.error(
+                `Error during getAllIflowsByPackage test for package ${testPackageId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -96,8 +105,11 @@ describe("IFlow Management API", () => {
             // Optionally check for expected files within the downloaded structure (e.g., META-INF)
             await fs.access(path.join(iflowPath, 'META-INF', 'MANIFEST.MF'));
         } catch (error) {
-            console.error(`Error during getIflowFolder test for ${testIflowId}:`, error);
-            throw error;
+            console.error(
+                `Error during getIflowFolder test for ${testIflowId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         } finally {
             // Clean up the downloaded folder
             if (iflowPath) {
@@ -133,13 +145,16 @@ describe("IFlow Management API", () => {
              await fs.rm(iflowPath, { recursive: true, force: true });
 
         } catch (error) {
-            console.error(`Error during updateIflow test for ${testIflowId}:`, error);
+            console.error(
+                `Error during updateIflow test for ${testIflowId}:`,
+                safeStringify(error)
+            );
              // Clean up potentially downloaded folder on error
              try {
                  const iflowPath = path.join(process.cwd(), 'temp', testIflowId); // Assuming temp folder structure
                  await fs.rm(iflowPath, { recursive: true, force: true });
              } catch (cleanupError) {}
-            throw error;
+            throw new Error((error as Error).message);
         }
     });
 
@@ -166,7 +181,10 @@ describe("IFlow Management API", () => {
             iflowDeployed = true;
 
         } catch (error) {
-            console.error(`Error during deployIflow/waitAndGetDeployStatus test for ${testIflowId}:`, error);
+            console.error(
+                `Error during deployIflow/waitAndGetDeployStatus test for ${testIflowId}:`,
+                safeStringify(error)
+            );
             // Attempt to get error reason even if wait failed
              try {
                  const errorReason = await getDeploymentErrorReason(testIflowId);
@@ -174,7 +192,7 @@ describe("IFlow Management API", () => {
              } catch (reasonError) {
                  console.error("Could not retrieve deployment error reason.", reasonError);
              }
-            throw error;
+            throw new Error((error as Error).message);
         }
     });
 
@@ -192,8 +210,11 @@ describe("IFlow Management API", () => {
             console.log(`Endpoints found for ${testIflowId}:`, JSON.stringify(endpoints, null, 2));
             // Add more specific checks if endpoints are expected for the base iflow
         } catch (error) {
-            console.error(`Error during getEndpoints test for ${testIflowId}:`, error);
-            throw error;
+            console.error(
+                `Error during getEndpoints test for ${testIflowId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -206,8 +227,11 @@ describe("IFlow Management API", () => {
              // Allow for 0 or more configurations, as default might exist
              expect(config.length).toBeGreaterThanOrEqual(0); // Re-applying this assertion
          } catch (error) {
-             console.error(`Error during getIflowConfiguration test for ${testIflowId}:`, error);
-             throw error;
+             console.error(
+                 `Error during getIflowConfiguration test for ${testIflowId}:`,
+                 safeStringify(error)
+             );
+             throw new Error((error as Error).message);
          }
      });
 
@@ -219,11 +243,14 @@ describe("IFlow Management API", () => {
              await saveAsNewVersion(testIflowId);
              // Verification would ideally involve getting the iflow details again and checking the version,
              // but the getIflow function isn't available directly here. We assume success if no error.
-         } catch (error) {
-             console.error(`Error during saveAsNewVersion test for ${testIflowId}:`, error);
-             throw error;
-         }
-     });
+        } catch (error) {
+            console.error(
+                `Error during saveAsNewVersion test for ${testIflowId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
+        }
+    });
 
      it("should get the iflow content as a string", async () => {
          expect(iflowCreated).toBe(true);
@@ -236,11 +263,14 @@ describe("IFlow Management API", () => {
              expect(contentString).toContain("// Test Groovy Script Content");
              expect(contentString).toContain("testScript.groovy");
              expect(contentString).toContain("MANIFEST.MF"); // From the base structure
-         } catch (error) {
-             console.error(`Error during getIflowContentString test for ${testIflowId}:`, error);
-             throw error;
-         }
-     });
+        } catch (error) {
+            console.error(
+                `Error during getIflowContentString test for ${testIflowId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
+        }
+    });
 
      it("should generate a diagram image for a specific iflow (if_simple_http_cld)", async () => {
         const targetIflowId = "if_simple_http_cld"; // The iFlow specified by the user
@@ -268,12 +298,18 @@ describe("IFlow Management API", () => {
                  // For now, just log and let it pass if the error is 'not found'.
                  // If it's another error, re-throw it.
                  if (!error.message.includes("Could not find")) {
-                    console.error(`Error during getiFlowToImage test for ${targetIflowId}:`, error);
-                    throw error;
+                    console.error(
+                        `Error during getiFlowToImage test for ${targetIflowId}:`,
+                        safeStringify(error)
+                    );
+                    throw new Error((error as Error).message);
                  }
             } else {
-                console.error(`Error during getiFlowToImage test for ${targetIflowId}:`, error);
-                throw error;
+                console.error(
+                    `Error during getiFlowToImage test for ${targetIflowId}:`,
+                    safeStringify(error)
+                );
+                throw new Error((error as Error).message);
             }
         } finally {
             // Clean up the downloaded folder regardless of success or failure

--- a/src/api/__tests__/messageLogs.test.ts
+++ b/src/api/__tests__/messageLogs.test.ts
@@ -9,7 +9,7 @@ import { getAllIflowsByPackage, deployIflow } from "../iflow/index"; // Need to 
 import { waitAndGetDeployStatus, getDeploymentErrorReason } from "../deployment"; // Need deployment status check
 import dotenv from 'dotenv';
 import moment from 'moment';
-import { deletePackage } from "./helpers";
+import { deletePackage, safeStringify } from "./helpers";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -38,7 +38,10 @@ describe("Message Log API", () => {
             packageCreated = true;
             console.log(`Test package ${testPackageId} created successfully.`);
         } catch (error) {
-            console.error(`Failed to create test package ${testPackageId}. Message Log tests will likely fail. Error:`, error);
+            console.error(
+                `Failed to create test package ${testPackageId}. Message Log tests will likely fail. Error:`,
+                safeStringify(error)
+            );
             throw new Error(`Failed to create prerequisite package ${testPackageId}`);
         }
     });
@@ -68,13 +71,16 @@ describe("Message Log API", () => {
              console.log(`IFlow ${testIflowId} deployed successfully.`);
 
         } catch (error) {
-            console.error(`Error during createMappingTestIflow test for package ${testPackageId}:`, error);
+            console.error(
+                `Error during createMappingTestIflow test for package ${testPackageId}:`,
+                safeStringify(error)
+            );
             // Attempt to get error reason if deployment might have failed
             try {
                  const errorReason = await getDeploymentErrorReason(testIflowId);
                  console.error(`Deployment error reason for ${testIflowId}: ${errorReason}`);
              } catch (reasonError) {}
-            throw error;
+            throw new Error((error as Error).message);
         }
     });
 
@@ -93,8 +99,11 @@ describe("Message Log API", () => {
             expect(count).toBeGreaterThanOrEqual(0); // Count can be 0
             console.log(`Found ${count} messages in the last 5 minutes.`);
         } catch (error) {
-            console.error(`Error during getMessagesCount test:`, error);
-            throw error;
+            console.error(
+                `Error during getMessagesCount test:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -120,8 +129,11 @@ describe("Message Log API", () => {
                 // Check structure of retrieved messages if needed
             }
         } catch (error) {
-            console.error(`Error during getMessages test:`, error);
-            throw error;
+            console.error(
+                `Error during getMessages test:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -147,8 +159,11 @@ describe("Message Log API", () => {
             console.log(`Successfully retrieved error message log ${messageGuid}. Status: ${message.status}`);
 
         } catch (error) {
-            console.error(`Error during getMessages test for specific GUID ${messageGuid}:`, error);
-            throw error;
+            console.error(
+                `Error during getMessages test for specific GUID ${messageGuid}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -196,8 +211,11 @@ describe("Message Log API", () => {
             console.log(`Successfully retrieved error message log ${messageGuid} with attachments. Status: ${message.status}`);
 
         } catch (error) {
-            console.error(`Error during getMessages test for specific GUID ${messageGuid} with attachments:`, error);
-            throw error;
+            console.error(
+                `Error during getMessages test for specific GUID ${messageGuid} with attachments:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 

--- a/src/api/__tests__/packages.test.ts
+++ b/src/api/__tests__/packages.test.ts
@@ -4,7 +4,7 @@ import { createPackage, getPackage, getPackages } from "../packages/index";
 import { integrationContent, IntegrationPackages } from "../../generated/IntegrationContent/index";
 import dotenv from 'dotenv';
 import { getCurrentDestination } from "../api_destination";
-import { deletePackage } from "./helpers";
+import { deletePackage, safeStringify } from "./helpers";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -32,7 +32,10 @@ describe("Package Management API", () => {
             packageCreated = true;
             console.log(`Test package ${testPackageId} created successfully.`);
         } catch (error) {
-            console.error(`Failed to create test package ${testPackageId}. Some tests might fail or be skipped. Error:`, error);
+            console.error(
+                `Failed to create test package ${testPackageId}. Some tests might fail or be skipped. Error:`,
+                safeStringify(error)
+            );
             // Decide if tests should proceed without the package
             // For now, we'll let them run and potentially fail if they depend on the created package.
         }
@@ -60,8 +63,11 @@ describe("Package Management API", () => {
                 expect(found).toBe(true);
             }
         } catch (error) {
-            console.error("Error during getPackages test:", error);
-            throw error;
+            console.error(
+                "Error during getPackages test:",
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -77,8 +83,11 @@ describe("Package Management API", () => {
             expect(pkg.name).toEqual(`Jest Test Package`);
             // Add more assertions based on expected package structure if needed
         } catch (error) {
-            console.error(`Error during getPackage test for ID ${testPackageId}:`, error);
-            throw error;
+            console.error(
+                `Error during getPackage test for ID ${testPackageId}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 

--- a/src/api/__tests__/sendMessageToCPI.test.ts
+++ b/src/api/__tests__/sendMessageToCPI.test.ts
@@ -1,6 +1,7 @@
 import { sendRequestToCPI } from "../messages/sendMessageToCPI";
 import { getEndpoints } from "../iflow/index"; // To potentially find a real endpoint
 import dotenv from 'dotenv';
+import { safeStringify } from "./helpers";
 
 // Load environment variables from .env file
 dotenv.config();
@@ -54,8 +55,11 @@ describe("Send Message to CPI API", () => {
             console.log(`sendRequestToCPI to ${testPath} completed with status: ${result.status}`);
 
         } catch (error) {
-            console.error(`Error during sendRequestToCPI test to ${testPath}:`, error);
-            throw error;
+            console.error(
+                `Error during sendRequestToCPI test to ${testPath}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -85,8 +89,11 @@ describe("Send Message to CPI API", () => {
             console.log(`sendRequestToCPI (POST) to ${testPath} completed with status: ${result.status}`);
 
         } catch (error) {
-            console.error(`Error during sendRequestToCPI (POST) test to ${testPath}:`, error);
-            throw error;
+            console.error(
+                `Error during sendRequestToCPI (POST) test to ${testPath}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 
@@ -151,8 +158,11 @@ describe("Send Message to CPI API", () => {
             console.log(`sendRequestToCPI (POST) to ${echoEndpointPath} completed with status: ${result.status}`);
 
         } catch (error) {
-            console.error(`Error during sendRequestToCPI (POST) test to ${echoEndpointPath}:`, error);
-            throw error;
+            console.error(
+                `Error during sendRequestToCPI (POST) test to ${echoEndpointPath}:`,
+                safeStringify(error)
+            );
+            throw new Error((error as Error).message);
         }
     });
 


### PR DESCRIPTION
## Summary
- update `deletePackage` helper and add `safeStringify`
- rethrow API errors using new Error and log using safe JSON stringify

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ad0662e48327ba4e0b1c99b0a446