### PR TITLE
Fix diagram test uses created iFlow

### DIFF
--- a/src/api/__tests__/iflow.test.ts
+++ b/src/api/__tests__/iflow.test.ts
@@ -272,8 +272,8 @@ describe("IFlow Management API", () => {
         }
     });
 
-     it("should generate a diagram image for a specific iflow (if_simple_http_cld)", async () => {
-        const targetIflowId = "if_simple_http_cld"; // The iFlow specified by the user
+     it("should generate a diagram image for the created iflow", async () => {
+        const targetIflowId = testIflowId; // Use the iflow created earlier
         let iflowPath: string | undefined;
         try {
             console.log(`Attempting to download folder for diagram test: ${targetIflowId}`);


### PR DESCRIPTION
## Summary
- use the iFlow created in the same test suite when generating a diagram

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b4534e3883278ce0e38007e4a2d2